### PR TITLE
Add how to release to Readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,11 @@ The following rule governs code contributions:
 * We use GitHub issues to track bugs and enhancement requests.
 
 * Please provide as much context as possible when you open an issue. The information you provide must be comprehensive enough to reproduce that issue for the assignee.
+
+## Creating a new release
+
+Create a new PR with the following changes:
+
+1. Modify the `VERSION` file
+2. Run `make helm-chart`
+3. After your PR is approved and merged, a new version of the image and helm chart will automatically be build and published


### PR DESCRIPTION
fyi @moelsayed @maximiliantech 

The make helm-chart was not run for the 0.1.4 release. For now I have added it to the Readme to do it. But I think it makes sense to have a GH pipeline which checks for it:

Could by like
* if file VERSION has changed, run make helm-chart in bash and use git to check that nothing has changed
