### PR TITLE
allow setting FIPS mode at runtime and build against frozen go/crypto

### DIFF
--- a/charts/control-plane-operator/templates/deployment.yaml
+++ b/charts/control-plane-operator/templates/deployment.yaml
@@ -80,6 +80,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
+            - name: GODEBUG
+              value: "fips140={{ .Values.fips.mode }}"
           {{- with .Values.init.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -177,6 +179,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
+            - name: GODEBUG
+              value: "fips140={{ .Values.fips.mode }}"
           {{- with .Values.manager.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/control-plane-operator/values.yaml
+++ b/charts/control-plane-operator/values.yaml
@@ -148,6 +148,9 @@ rbac:
   role:
     rules: []
 
+fips:
+  mode: "off" # controls GODEBUG=fips140 setting. Set to either off, on, or only (refer to https://go.dev/doc/security/fips140#fips-140-3-mode)
+
 nodeSelector: {}
 
 tolerations: []

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"crypto/fips140"
 	"embed"
 	"flag"
 	"os"
@@ -128,6 +129,13 @@ func main() {
 	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// needs to be run after ctrl.SetLogger has been called, so we can log
+	if fips140.Enabled() {
+		setupLog.Info("Running in FIPS 140-3 compliant mode")
+	} else {
+		setupLog.Info("Running in non-FIPS-compliant mode")
+	}
 
 	setupContext := context.Background()
 

--- a/hack/common/build-binary.sh
+++ b/hack/common/build-binary.sh
@@ -12,7 +12,7 @@ echo "> Building binaries ..."
       echo "> Building binary for component '$comp' ($pf) ..." | indent 1
       os=${pf%/*}
       arch=${pf#*/}
-      CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -a -o bin/${comp}-${os}.${arch} cmd/main.go | indent 2
+      CGO_ENABLED=0 GOFIPS140=v1.0.0 GOOS=$os GOARCH=$arch go build -a -o bin/${comp}-${os}.${arch} cmd/main.go | indent 2
     done
   done
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes internal-backlog number 34

**Special notes for your reviewer**:

A short explanation of how FIPS in Go 1.24 works in general (from here https://go.dev/doc/security/fips140):
Passing the `GOFIPS140=v1.0.0` flag to `go build` ensures that a frozen version of the Go crypto lib from early 2025 is linked into the binary. This is important as this version is currently being certified for FIPS. Furthermore, the `GODEBUG=fips140=only` setting ensures that the program is going to panic or return an error if a fips incompliant crypto lib function is being called (e.g. `crypto/sha1.Sum`). Without it the program would just continue running.

Things that need to be discussed where we have some leeway:

Currently my implementation follows the motto: _FIPS first, no FIPS possible_

1. Currently the binary on startup prints out in which mode it is running. While it is a bit more copy-paste effort for every operator, I think this is worth it as you then can easily tell in which mode the binary is running. Do you agree?
2. I think we should allow the operator to be run in non-FIPS mode as well. Reason being is that if we ever encounter an issue with FIPS (for example invalid cipher panic), we can easily run in non-FIPS mode on dev temporarily to narrow down the issue. The implications of this choice are that we should add an option into our values in the helm chart (see this PR). Wdyt?

Update Apr 15th: Was decided to keep as proposed


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
