### PR TITLE
deploy permissions for deploymentruntimeconfigs with protection enabled

### DIFF
--- a/pkg/controlplane/components/crossplane_component.go
+++ b/pkg/controlplane/components/crossplane_component.go
@@ -9,7 +9,6 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/openmcp-project/control-plane-operator/api/v1beta1"
-	"github.com/openmcp-project/control-plane-operator/cmd/options"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler/fluxcd"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler/hooks"
@@ -82,15 +81,13 @@ func (c *Crossplane) GetPolicyRules() PolicyRules {
 		},
 	}
 
-	if options.IsDeploymentRuntimeConfigProtectionEnabled() {
-		rules.Admin = append(rules.Admin, rbacv1.PolicyRule{
-			APIGroups: []string{"pkg.crossplane.io"},
-			Resources: []string{
-				"deploymentruntimeconfigs",
-			},
-			Verbs: VerbsModify,
-		})
-	}
+	rules.Admin = append(rules.Admin, rbacv1.PolicyRule{
+		APIGroups: []string{"pkg.crossplane.io"},
+		Resources: []string{
+			"deploymentruntimeconfigs",
+		},
+		Verbs: VerbsModify,
+	})
 
 	return rules
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When the deploymentruntimeconfig protection is disabled, the configuration of the clusterrole giving admins permissions to deploymentruntimeconfigs is disabled as well.
As there is currently no intention to switch the protection on by default, users should gain access to deploymentruntimeconfigs regardless.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow admin users to create/modify deploymentruntimeconfigs when protection is disabled
```
