### PR TITLE
fix(component): permissions for accessing Crossplane `Usage` resources

### DIFF
--- a/pkg/controlplane/components/crossplane_component.go
+++ b/pkg/controlplane/components/crossplane_component.go
@@ -54,6 +54,7 @@ func (c *Crossplane) GetPolicyRules() PolicyRules {
 					"compositeresourcedefinitions",
 					"compositions",
 					"environmentconfigs",
+					"usages",
 				},
 				Verbs: VerbsAdmin,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simply fixes a permission issue where end-users could not use their admin permissions to create/update/delete `Usage` resources.

**Which issue(s) this PR fixes**:
Fixes https://github.com/openmcp-project/control-plane-operator/issues/87

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixing permission issues on Crossplane `Usage` resources
```
