### PR TITLE
feat: skip-reconciliation annotation for object-based components

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ More information can be found via the [Kubebuilder Documentation](https://book.k
 
 ### How can I stop the operator from managing an existing resource?
 
-Add the annotation `controlplane.core.orchestrate.cloud.sap/skip-reconciliation: "true"` to the existing managed object.
+Add the annotation `core.orchestrate.cloud.sap/skip-reconciliation: "true"` to the existing managed object.
 
 When this annotation is present, the operator skips reconciliation for that resource entirely. This means neither desired-state changes nor drift from the expected state will be applied granting manual control over the resource.
 The annotation works on the following components:
@@ -152,6 +152,7 @@ The annotation works on the following components:
 - CrossplaneDeploymentRuntimeConfig
 - Secret
 - ClusterRole
+- GenericObjectComponent
 
 
 ## Support, Feedback, Contributing

--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ cluster.
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 
+## FAQ
+
+### How can I stop the operator from managing an existing resource?
+
+Add the annotation `controlplane.core.orchestrate.cloud.sap/skip-reconciliation: "true"` to the existing managed object.
+
+When this annotation is present, the operator skips reconciliation for that resource entirely. This means neither desired-state changes nor drift from the expected state will be applied granting manual control over the resource.
+The annotation works on the following components:
+
+- CrossplaneProvider
+- CrossplaneDeploymentRuntimeConfig
+- Secret
+- ClusterRole
+
 
 ## Support, Feedback, Contributing
 

--- a/internal/controller/controlplane_controller.go
+++ b/internal/controller/controlplane_controller.go
@@ -223,7 +223,7 @@ func (r *ControlPlaneReconciler) updateControlPlaneComponents(ctx context.Contex
 		if componentResult.Component.IsEnabled() {
 			enabledComponents++
 		}
-		if componentResult.Result == juggler.StatusHealthy {
+		if componentResult.Result == juggler.StatusHealthy || componentResult.Result == juggler.StatusHealthyReconciliationSkipped {
 			healthyComponents++
 		}
 

--- a/pkg/constants/annotation.go
+++ b/pkg/constants/annotation.go
@@ -2,5 +2,5 @@ package constants
 
 const (
 	AnnotationCredentialsForUrl  = "core.orchestrate.cloud.sap/credentials-for-url"
-	AnnotationSkipReconciliation = "controlplane.core.orchestrate.cloud.sap/skip-reconciliation"
+	AnnotationSkipReconciliation = "core.orchestrate.cloud.sap/skip-reconciliation"
 )

--- a/pkg/constants/annotation.go
+++ b/pkg/constants/annotation.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
-	AnnotationCredentialsForUrl = "core.orchestrate.cloud.sap/credentials-for-url"
+	AnnotationCredentialsForUrl  = "core.orchestrate.cloud.sap/credentials-for-url"
+	AnnotationSkipReconciliation = "controlplane.core.orchestrate.cloud.sap/skip-reconciliation"
 )

--- a/pkg/juggler/component.go
+++ b/pkg/juggler/component.go
@@ -101,13 +101,13 @@ var (
 	// StatusUpdateFailed states that a component could not be updated.
 	StatusUpdateFailed = ComponentStatus{Name: "UpdateFailed", IsReady: false, EmitsEvent: ComponentEventWarning}
 
-	// StatusSkipped states that a component is healthy but reconciliation is skipped.
+	// StatusUnhealthyReconciliationSkipped states that a component is unhealthy and the reconciliation is skipped.
 	StatusUnhealthyReconciliationSkipped = ComponentStatus{Name: "ReconciliationSkipped", IsReady: false, EmitsEvent: ComponentEventNormal}
 
 	// StatusUnhealthy states that a component is unhealthy.
 	StatusUnhealthy = ComponentStatus{Name: "Unhealthy", IsReady: false, EmitsEvent: ComponentEventNone}
 
-	// StatusSkipped states that a component is healthy but reconciliation is skipped.
+	// StatusHealthyReconciliationSkipped states that a component is healthy but reconciliation is skipped.
 	StatusHealthyReconciliationSkipped = ComponentStatus{Name: "ReconciliationSkipped", IsReady: true, EmitsEvent: ComponentEventNormal}
 
 	// StatusHealthy states that a component is healthy and no action has been taken.

--- a/pkg/juggler/component.go
+++ b/pkg/juggler/component.go
@@ -101,8 +101,14 @@ var (
 	// StatusUpdateFailed states that a component could not be updated.
 	StatusUpdateFailed = ComponentStatus{Name: "UpdateFailed", IsReady: false, EmitsEvent: ComponentEventWarning}
 
+	// StatusSkipped states that a component is healthy but reconciliation is skipped.
+	StatusUnhealthyReconciliationSkipped = ComponentStatus{Name: "ReconciliationSkipped", IsReady: false, EmitsEvent: ComponentEventNormal}
+
 	// StatusUnhealthy states that a component is unhealthy.
 	StatusUnhealthy = ComponentStatus{Name: "Unhealthy", IsReady: false, EmitsEvent: ComponentEventNone}
+
+	// StatusSkipped states that a component is healthy but reconciliation is skipped.
+	StatusHealthyReconciliationSkipped = ComponentStatus{Name: "ReconciliationSkipped", IsReady: true, EmitsEvent: ComponentEventNormal}
 
 	// StatusHealthy states that a component is healthy and no action has been taken.
 	StatusHealthy = ComponentStatus{Name: "Healthy", IsReady: true, EmitsEvent: ComponentEventNone}

--- a/pkg/juggler/juggler.go
+++ b/pkg/juggler/juggler.go
@@ -240,10 +240,27 @@ func (am *Juggler) reconcileComponent(ctx context.Context, component Component) 
 
 	// Resource is not healthy
 	if !observation.Healthy {
+		// Resource is skipped
+		if observation.ResourceSkipped {
+			return ComponentResult{
+				Component: component,
+				Result:    StatusUnhealthyReconciliationSkipped,
+				Message:   fmt.Sprintf("Reconciliation of %s skipped due to skip-reconciliation annotation.", component.GetName()),
+			}
+		}
 		return ComponentResult{
 			Component: component,
 			Result:    StatusUnhealthy,
 			Message:   observation.Message,
+		}
+	}
+
+	// Resource is healthy but reconciliation is skipped
+	if observation.ResourceSkipped {
+		return ComponentResult{
+			Component: component,
+			Result:    StatusHealthyReconciliationSkipped,
+			Message:   fmt.Sprintf("Reconciliation of %s skipped due to skip-reconciliation annotation.", component.GetName()),
 		}
 	}
 

--- a/pkg/juggler/juggler_test.go
+++ b/pkg/juggler/juggler_test.go
@@ -592,6 +592,54 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 				Message: fmt.Sprintf("FakeComponent is installed but current version is not in release channel: available versions: %s", errBoom),
 			},
 		},
+		{
+			name: "is not healthy and skipped",
+			args: args{
+				component: FakeComponent{Enabled: true, Allowed: true},
+				reconciler: FakeReconciler{
+					KnownTypesFunc: knowsAll(),
+					ObserverFunc: func(ctx context.Context, component Component) (ComponentObservation, error) {
+						return ComponentObservation{
+							ResourceExists: true,
+							ResourceHealthiness: ResourceHealthiness{
+								Healthy: false,
+								Message: "not healthy",
+							},
+							ResourceSkipped: true,
+						}, nil
+					},
+				},
+			},
+			want: ComponentResult{
+				Component: FakeComponent{Enabled: true, Allowed: true},
+				Result:    StatusUnhealthyReconciliationSkipped,
+				Message:   "Reconciliation of FakeComponent skipped due to skip-reconciliation annotation.",
+			},
+		},
+		{
+			name: "is healthy and skipped",
+			args: args{
+				component: FakeComponent{Enabled: true, Allowed: true},
+				reconciler: FakeReconciler{
+					KnownTypesFunc: knowsAll(),
+					ObserverFunc: func(ctx context.Context, component Component) (ComponentObservation, error) {
+						return ComponentObservation{
+							ResourceExists: true,
+							ResourceHealthiness: ResourceHealthiness{
+								Healthy: true,
+								Message: "",
+							},
+							ResourceSkipped: true,
+						}, nil
+					},
+				},
+			},
+			want: ComponentResult{
+				Component: FakeComponent{Enabled: true, Allowed: true},
+				Result:    StatusHealthyReconciliationSkipped,
+				Message:   "Reconciliation of FakeComponent skipped due to skip-reconciliation annotation.",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/juggler/object/object_reconciler.go
+++ b/pkg/juggler/object/object_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -11,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/openmcp-project/control-plane-operator/pkg/constants"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 	"github.com/openmcp-project/control-plane-operator/pkg/utils"
 )
@@ -203,9 +205,40 @@ func (r *ObjectReconciler) applyObject(ctx context.Context, component juggler.Co
 	obj.SetName(key.Name)
 	obj.SetNamespace(key.Namespace)
 
+	existing := obj.DeepCopyObject().(client.Object)
+
+	err = r.remoteClient.Get(ctx, key, existing)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
+	// Only evaluate skip-reconciliation annotation on existing objects
+	if err == nil && shouldSkipReconciliation(existing) {
+		r.logger.Info("Skipping update due to skip-reconciliation annotation on object", "name", key.Name, "namespace", key.Namespace)
+		return nil
+	}
+
 	_, err = controllerutil.CreateOrUpdate(ctx, r.remoteClient, obj, func() error {
 		utils.SetLabels(obj, r.labelFunc(component))
 		return objectComponent.ReconcileObject(ctx, obj)
 	})
 	return err
+}
+
+func shouldSkipReconciliation(obj client.Object) bool {
+	if obj == nil {
+		return false
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	value, exists := annotations[constants.AnnotationSkipReconciliation]
+	if !exists {
+		return false
+	}
+
+	return strings.EqualFold(value, "true")
 }

--- a/pkg/juggler/object/object_reconciler.go
+++ b/pkg/juggler/object/object_reconciler.go
@@ -142,6 +142,7 @@ func (r *ObjectReconciler) Observe(ctx context.Context, comp juggler.Component) 
 
 	return juggler.ComponentObservation{
 		ResourceExists:      true,
+		ResourceSkipped:     shouldSkipReconciliation(obj),
 		ResourceHealthiness: objectComponent.IsObjectHealthy(obj),
 	}, nil
 }
@@ -205,20 +206,11 @@ func (r *ObjectReconciler) applyObject(ctx context.Context, component juggler.Co
 	obj.SetName(key.Name)
 	obj.SetNamespace(key.Namespace)
 
-	existing := obj.DeepCopyObject().(client.Object)
-
-	err = r.remoteClient.Get(ctx, key, existing)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-
-	// Only evaluate skip-reconciliation annotation on existing objects
-	if err == nil && shouldSkipReconciliation(existing) {
-		r.logger.Info("Skipping update due to skip-reconciliation annotation on object", "name", key.Name, "namespace", key.Namespace)
-		return nil
-	}
-
 	_, err = controllerutil.CreateOrUpdate(ctx, r.remoteClient, obj, func() error {
+		if shouldSkipReconciliation(obj) {
+			r.logger.Info("Skipping update due to skip-reconciliation annotation on object", "name", key.Name, "namespace", key.Namespace)
+			return nil
+		}
 		utils.SetLabels(obj, r.labelFunc(component))
 		return objectComponent.ReconcileObject(ctx, obj)
 	})

--- a/pkg/juggler/object/object_reconciler.go
+++ b/pkg/juggler/object/object_reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -222,15 +221,5 @@ func shouldSkipReconciliation(obj client.Object) bool {
 		return false
 	}
 
-	annotations := obj.GetAnnotations()
-	if annotations == nil {
-		return false
-	}
-
-	value, exists := annotations[constants.AnnotationSkipReconciliation]
-	if !exists {
-		return false
-	}
-
-	return strings.EqualFold(value, "true")
+	return obj.GetAnnotations()[constants.AnnotationSkipReconciliation] == "true"
 }

--- a/pkg/juggler/object/object_reconciler_test.go
+++ b/pkg/juggler/object/object_reconciler_test.go
@@ -94,6 +94,39 @@ func TestObjectReconciler_Install(t *testing.T) {
 			},
 		},
 		{
+			name: "ObjectComponent BuildObject successful - Creation successful - Labels not set due to skip annotation",
+			obj: FakeObjectComponent{
+				BuildObjectToReconcileFunc: func(ctx context.Context) (client.Object, types.NamespacedName, error) {
+					return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									constants.AnnotationSkipReconciliation: "true",
+								},
+							},
+						}, types.NamespacedName{
+
+							Name:      "test",
+							Namespace: "default",
+						}, nil
+				},
+				ReconcileObjectFunc: func(ctx context.Context, obj client.Object) error {
+					return nil
+				},
+				name: "FakeObjectComponent",
+			},
+			validateFunc: func(ctx context.Context, c client.Client, comp juggler.Component) error {
+				secret := &corev1.Secret{}
+				err := c.Get(ctx, client.ObjectKey{Name: "test", Namespace: "default"}, secret)
+				if err != nil {
+					return err
+				}
+				if !assert.Empty(t, secret.GetLabels()) {
+					return errors.New("labels not empty")
+				}
+				return nil
+			},
+		},
+		{
 			name: "ObjectComponent BuildObject successful - Object already there - Update successful",
 			obj: FakeObjectComponent{
 				BuildObjectToReconcileFunc: func(ctx context.Context) (client.Object, types.NamespacedName, error) {
@@ -612,6 +645,48 @@ func TestObjectReconciler_Observe(t *testing.T) {
 			},
 			expectedObservation: juggler.ComponentObservation{
 				ResourceExists: true,
+				ResourceHealthiness: juggler.ResourceHealthiness{
+					Healthy: true,
+					Message: "",
+				},
+			},
+		},
+		{
+			name: "ObjectComponent BuildObject successful - Object found - Skip annotation set",
+			obj: FakeObjectComponent{
+				BuildObjectToReconcileFunc: func(ctx context.Context) (client.Object, types.NamespacedName, error) {
+					return &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Annotations: map[string]string{
+									constants.AnnotationSkipReconciliation: "true",
+								},
+							},
+						}, types.NamespacedName{
+							Name:      "test",
+							Namespace: "default",
+						}, nil
+				},
+				IsObjectHealthyFunc: func(obj client.Object) juggler.ResourceHealthiness {
+					return juggler.ResourceHealthiness{
+						Healthy: true,
+						Message: "",
+					}
+				},
+			},
+			remoteObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+						Annotations: map[string]string{
+							constants.AnnotationSkipReconciliation: "true",
+						},
+					},
+				},
+			},
+			expectedObservation: juggler.ComponentObservation{
+				ResourceExists:  true,
+				ResourceSkipped: true,
 				ResourceHealthiness: juggler.ResourceHealthiness{
 					Healthy: true,
 					Message: "",

--- a/pkg/juggler/object/object_reconciler_test.go
+++ b/pkg/juggler/object/object_reconciler_test.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	"github.com/openmcp-project/control-plane-operator/pkg/constants"
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 )
 
@@ -131,6 +132,49 @@ func TestObjectReconciler_Install(t *testing.T) {
 				}
 				if !assert.Equal(t, secret.Type, corev1.SecretTypeDockerConfigJson) {
 					return errors.New("type not equal")
+				}
+				return nil
+			},
+		},
+		{
+			name: "ObjectComponent BuildObject successful - Object already there - Update skipped",
+			obj: FakeObjectComponent{
+				BuildObjectToReconcileFunc: func(ctx context.Context) (client.Object, types.NamespacedName, error) {
+					return &corev1.Secret{}, types.NamespacedName{
+						Name:      "test",
+						Namespace: "default",
+					}, nil
+				},
+				ReconcileObjectFunc: func(ctx context.Context, obj client.Object) error {
+					secret := obj.(*corev1.Secret)
+					secret.Type = corev1.SecretTypeDockerConfigJson
+					secret.Labels = map[string]string{testLabelComponentKey: "do-not-apply"}
+					return nil
+				},
+				name: "FakeObjectComponent",
+			},
+			remoteObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+						Annotations: map[string]string{
+							constants.AnnotationSkipReconciliation: "true",
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
+				},
+			},
+			validateFunc: func(ctx context.Context, c client.Client, comp juggler.Component) error {
+				secret := &corev1.Secret{}
+				if err := c.Get(ctx, client.ObjectKey{Name: "test", Namespace: "default"}, secret); err != nil {
+					return err
+				}
+				if !assert.Equal(t, secret.Type, corev1.SecretTypeOpaque) {
+					return errors.New("secret type has changed")
+				}
+				if !assert.Empty(t, secret.Labels) {
+					return errors.New("secret labels have changed")
 				}
 				return nil
 			},

--- a/pkg/juggler/reconciler.go
+++ b/pkg/juggler/reconciler.go
@@ -28,7 +28,8 @@ type ComponentReconciler interface {
 }
 
 type ComponentObservation struct {
-	ResourceExists bool
+	ResourceExists  bool
+	ResourceSkipped bool
 	ResourceHealthiness
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces an annotation `controlplane.core.orchestrate.cloud.sap/skip-reconciliation` for object-based components which will make the controller ignore existing resources during reconciliation when set to `true`.

**Which issue(s) this PR fixes**:
Fixes #156

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added support for a skip-reconciliation annotation `controlplane.core.orchestrate.cloud.sap/skip-reconciliation` on object-based components to skip them during reconciliation allowing the user to temporarily take manual control
```
