### PR TITLE
feat: gracefully handle invalid releasechannel versions

### DIFF
--- a/api/v1beta1/releasechannel_types.go
+++ b/api/v1beta1/releasechannel_types.go
@@ -24,6 +24,9 @@ import (
 // +kubebuilder:object:generate=false
 type VersionResolverFn func(componentName string, version string) (ComponentVersion, error)
 
+// +kubebuilder:object:generate=false
+type VersionsResolverFn func(componentName string) ([]string, error)
+
 // ReleaseChannelSpec defines the desired state of ReleaseChannel
 type ReleaseChannelSpec struct {
 	// Specify a ocm registry url where the releasechannel components are uploaded

--- a/api/v1beta1/releasechannel_types.go
+++ b/api/v1beta1/releasechannel_types.go
@@ -25,7 +25,7 @@ import (
 type VersionResolverFn func(componentName string, version string) (ComponentVersion, error)
 
 // +kubebuilder:object:generate=false
-type VersionsResolverFn func(componentName string) ([]string, error)
+type AvailableVersionsResolverFn func(componentName string) ([]string, error)
 
 // ReleaseChannelSpec defines the desired state of ReleaseChannel
 type ReleaseChannelSpec struct {

--- a/internal/controller/controlplane_controller.go
+++ b/internal/controller/controlplane_controller.go
@@ -122,7 +122,7 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	resolverFn := r.getReleaseChannels(ctx)
 	ctx = rcontext.WithVersionResolver(ctx, resolverFn)
-	ctx = rcontext.WithVersionsResolver(ctx, r.getComponentVersions(ctx))
+	ctx = rcontext.WithAvailableVersionsResolver(ctx, r.getComponentAvailableVersions(ctx))
 	ctx = rcontext.WithSecretRefResolver(ctx, r.FluxSecretResolver.Resolve)
 
 	// get a remote config for the target cluster
@@ -190,10 +190,10 @@ func (r *ControlPlaneReconciler) getReleaseChannels(ctx context.Context) corev1b
 	}
 }
 
-// getComponentVersions returns a function that can be used to get all available versions of a component.
-func (r *ControlPlaneReconciler) getComponentVersions(ctx context.Context) corev1beta1.VersionsResolverFn {
+// getComponentAvailableVersions returns a function that can be used to get all available versions of a component.
+func (r *ControlPlaneReconciler) getComponentAvailableVersions(ctx context.Context) corev1beta1.AvailableVersionsResolverFn {
 	return func(componentName string) ([]string, error) {
-		return ocm.GetOCMComponentVersions(ctx, r.Client, componentName)
+		return ocm.GetOCMComponentAvailableVersions(ctx, r.Client, componentName)
 	}
 }
 

--- a/internal/controller/controlplane_controller.go
+++ b/internal/controller/controlplane_controller.go
@@ -122,6 +122,7 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	resolverFn := r.getReleaseChannels(ctx)
 	ctx = rcontext.WithVersionResolver(ctx, resolverFn)
+	ctx = rcontext.WithVersionsResolver(ctx, r.getComponentVersions(ctx))
 	ctx = rcontext.WithSecretRefResolver(ctx, r.FluxSecretResolver.Resolve)
 
 	// get a remote config for the target cluster
@@ -186,6 +187,13 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *ControlPlaneReconciler) getReleaseChannels(ctx context.Context) corev1beta1.VersionResolverFn {
 	return func(componentName string, version string) (corev1beta1.ComponentVersion, error) {
 		return ocm.GetOCMComponent(ctx, r.Client, componentName, version)
+	}
+}
+
+// getComponentVersions returns a function that can be used to get all available versions of a component.
+func (r *ControlPlaneReconciler) getComponentVersions(ctx context.Context) corev1beta1.VersionsResolverFn {
+	return func(componentName string) ([]string, error) {
+		return ocm.GetOCMComponentVersions(ctx, r.Client, componentName)
 	}
 }
 

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -229,7 +229,7 @@ func GetOCMComponent(
 	return v1beta1.ComponentVersion{}, fmt.Errorf("component %s with version %s not found", componentName, version)
 }
 
-func GetOCMComponentVersions(
+func GetOCMComponentAvailableVersions(
 	ctx context.Context,
 	client client.Client,
 	componentName string,

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -16,6 +16,7 @@ import (
 	"ocm.software/ocm/api/ocm/ocmutils"
 	"ocm.software/ocm/api/tech/oci/identity"
 	"ocm.software/ocm/api/utils/accessobj"
+	"ocm.software/ocm/api/utils/semverutils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -226,4 +227,32 @@ func GetOCMComponent(
 	}
 
 	return v1beta1.ComponentVersion{}, fmt.Errorf("component %s with version %s not found", componentName, version)
+}
+
+func GetOCMComponentVersions(
+	ctx context.Context,
+	client client.Client,
+	componentName string,
+) ([]string, error) {
+	releasechannels := v1beta1.ReleaseChannelList{}
+	err := client.List(ctx, &releasechannels)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, releasechannel := range releasechannels.Items {
+		components := releasechannel.Status.Components
+		for _, component := range components {
+			if component.Name == componentName {
+				versions := make([]string, 0, len(component.Versions))
+				for _, componentVersion := range component.Versions {
+					versions = append(versions, componentVersion.Version)
+				}
+				_ = semverutils.SortVersions(versions)
+				return versions, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("no versions found for component %s", componentName)
 }

--- a/internal/ocm/ocm.go
+++ b/internal/ocm/ocm.go
@@ -199,6 +199,8 @@ func GetOCMComponentsWithVersions(ctx context.Context, repo ocm.Repository, comp
 	return componentList, nil
 }
 
+var ErrComponentVersionNotFound = errors.New("component version not found")
+
 // GetOCMComponent takes a component name and a version as input and searches in an OCM registry if the component
 // with version is available. The function returns a Component object with the repository and version of the component.
 func GetOCMComponent(
@@ -226,7 +228,7 @@ func GetOCMComponent(
 		}
 	}
 
-	return v1beta1.ComponentVersion{}, fmt.Errorf("component %s with version %s not found", componentName, version)
+	return v1beta1.ComponentVersion{}, fmt.Errorf("%w: component %s with version %s", ErrComponentVersionNotFound, componentName, version)
 }
 
 func GetOCMComponentAvailableVersions(

--- a/internal/ocm/ocm_test.go
+++ b/internal/ocm/ocm_test.go
@@ -141,7 +141,7 @@ func TestGetOCMComponent(t *testing.T) {
 	}
 }
 
-func TestGetOCMComponentVersions(t *testing.T) {
+func TestGetOCMComponentAvailableVersions(t *testing.T) {
 	type input struct {
 		componentName    string
 		dockerconfigjson []byte
@@ -248,7 +248,7 @@ func TestGetOCMComponentVersions(t *testing.T) {
 				assert.NoError(t, testutils.SetEnvironmentVariableForLocalOCMTar(testutils.RepositoryPathInvalid))
 			}
 
-			got, err := GetOCMComponentVersions(ctx, c, tt.input.componentName)
+			got, err := GetOCMComponentAvailableVersions(ctx, c, tt.input.componentName)
 
 			if tt.want.err == nil {
 				assert.NoError(t, err)

--- a/internal/ocm/ocm_test.go
+++ b/internal/ocm/ocm_test.go
@@ -3,6 +3,7 @@ package ocm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -136,6 +137,125 @@ func TestGetOCMComponent(t *testing.T) {
 				assert.Errorf(t, err, tt.want.err.Error())
 			}
 			assert.Equal(t, got, tt.want.component)
+		})
+	}
+}
+
+func TestGetOCMComponentVersions(t *testing.T) {
+	type input struct {
+		componentName    string
+		dockerconfigjson []byte
+		validLocalRepo   bool
+	}
+	type want struct {
+		versions []string
+		err      error
+	}
+	tests := []struct {
+		name  string
+		input input
+		want  want
+	}{
+		{
+			name: "Can not find versions for component",
+			input: input{
+				dockerconfigjson: []byte("{}"),
+				validLocalRepo:   true,
+				componentName:    "invalidComponent",
+			},
+			want: want{
+				versions: nil,
+				err:      fmt.Errorf("no versions found for component %s", "invalidComponent"),
+			},
+		},
+		{
+			name: "Get single version for component",
+			input: input{
+				dockerconfigjson: []byte("{}"),
+				validLocalRepo:   true,
+				componentName:    "crossplane",
+			},
+			want: want{
+				versions: []string{"1.15.0"},
+				err:      nil,
+			},
+		},
+		{
+			name: "Get multiple versions for component sorted by semver",
+			input: input{
+				dockerconfigjson: []byte("{}"),
+				validLocalRepo:   true,
+				componentName:    "provider-helm",
+			},
+			want: want{
+				versions: []string{"0.19.0", "0.20.0"},
+				err:      nil,
+			},
+		},
+		{
+			name: "Get multiple versions for component not semver",
+			input: input{
+				dockerconfigjson: []byte("{}"),
+				validLocalRepo:   true,
+				componentName:    "provider-notsemver",
+			},
+			want: want{
+				versions: []string{"version-b", "version-a"},
+				err:      nil,
+			},
+		},
+	}
+
+	initObjs := []client.Object{
+		&corev1beta1.ReleaseChannel{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-releasechannel",
+			},
+			Status: corev1beta1.ReleaseChannelStatus{Components: []corev1beta1.Component{
+				{
+					Name: "crossplane",
+					Versions: []corev1beta1.ComponentVersion{
+						{Version: "1.15.0", HelmRepo: "https://charts.crossplane.io/stable", HelmChart: "crossplane"},
+					},
+				},
+				{
+					Name: "provider-helm",
+					Versions: []corev1beta1.ComponentVersion{
+						{Version: "0.19.0", DockerRef: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.19.0"},
+						{Version: "0.20.0", DockerRef: "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.20.0"},
+					},
+				},
+				{
+					Name: "provider-notsemver",
+					Versions: []corev1beta1.ComponentVersion{
+						{Version: "version-b", DockerRef: "xpkg.upbound.io/crossplane-contrib/provider-notsemver:version-b"},
+						{Version: "version-a", DockerRef: "xpkg.upbound.io/crossplane-contrib/provider-notsemver:version-a"},
+					},
+				},
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithObjects(initObjs...).WithStatusSubresource(initObjs[0]).WithScheme(schemes.Local).Build() //nolint:lll
+
+	ctx := newContext()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.input.validLocalRepo {
+				assert.NoError(t, testutils.SetEnvironmentVariableForLocalOCMTar(testutils.LocalOCMRepositoryPathValid))
+			} else {
+				assert.NoError(t, testutils.SetEnvironmentVariableForLocalOCMTar(testutils.RepositoryPathInvalid))
+			}
+
+			got, err := GetOCMComponentVersions(ctx, c, tt.input.componentName)
+
+			if tt.want.err == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, tt.want.err.Error())
+			}
+			assert.Equal(t, tt.want.versions, got)
 		})
 	}
 }

--- a/internal/ocm/ocm_test.go
+++ b/internal/ocm/ocm_test.go
@@ -2,7 +2,6 @@ package ocm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -46,7 +45,7 @@ func TestGetOCMComponent(t *testing.T) {
 			},
 			want: want{
 				component: corev1beta1.ComponentVersion{},
-				err:       errors.New("Component %s with version %s not found."),
+				err:       fmt.Errorf("%w: component %s with version %s", ErrComponentVersionNotFound, "invalidComponent", ""),
 			},
 		},
 		{
@@ -59,7 +58,7 @@ func TestGetOCMComponent(t *testing.T) {
 			},
 			want: want{
 				component: corev1beta1.ComponentVersion{},
-				err:       errors.New("Component %s with version %s not found."),
+				err:       fmt.Errorf("%w: component %s with version %s", ErrComponentVersionNotFound, "crossplane", "0.0.0"),
 			},
 		},
 		{
@@ -134,7 +133,9 @@ func TestGetOCMComponent(t *testing.T) {
 			if tt.want.err == nil {
 				assert.NoError(t, err)
 			} else {
-				assert.Errorf(t, err, tt.want.err.Error())
+				assert.Error(t, err)
+				assert.EqualError(t, err, tt.want.err.Error())
+				assert.ErrorIs(t, err, ErrComponentVersionNotFound)
 			}
 			assert.Equal(t, got, tt.want.component)
 		})

--- a/pkg/controlplane/components/btpso_component.go
+++ b/pkg/controlplane/components/btpso_component.go
@@ -75,7 +75,7 @@ func (btp *BTPServiceOperator) IsInstallable(ctx context.Context) (bool, error) 
 }
 
 func (btp *BTPServiceOperator) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(btpServiceOperatorRelease)
 }
 

--- a/pkg/controlplane/components/btpso_component.go
+++ b/pkg/controlplane/components/btpso_component.go
@@ -74,6 +74,11 @@ func (btp *BTPServiceOperator) IsInstallable(ctx context.Context) (bool, error) 
 	return true, nil
 }
 
+func (btp *BTPServiceOperator) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(btpServiceOperatorRelease)
+}
+
 func (btp *BTPServiceOperator) BuildSourceRepository(ctx context.Context) (fluxcd.SourceAdapter, error) {
 	rfn := rcontext.VersionResolver(ctx)
 	btp.applyDefaultChartSpec(rfn)

--- a/pkg/controlplane/components/btpso_component.go
+++ b/pkg/controlplane/components/btpso_component.go
@@ -68,6 +68,9 @@ func (btp *BTPServiceOperator) GetNamespace() string {
 
 func (btp *BTPServiceOperator) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(btpServiceOperatorRelease, btp.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/btpso_component_test.go
+++ b/pkg/controlplane/components/btpso_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_BTPServiceOperator(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.BTPServiceOperatorConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.BTPServiceOperatorConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_BTPServiceOperator(t *testing.T) {
 				hasName("BTPServiceOperator"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.BTPServiceOperatorConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("BTPServiceOperator"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.BTPServiceOperatorConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("BTPServiceOperator"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -67,7 +90,7 @@ func Test_BTPServiceOperator(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &BTPServiceOperator{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/btpso_component_test.go
+++ b/pkg/controlplane/components/btpso_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_BTPServiceOperator(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.BTPServiceOperatorConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.BTPServiceOperatorConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_BTPServiceOperator(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.BTPServiceOperatorConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.BTPServiceOperatorConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("BTPServiceOperator"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.BTPServiceOperatorConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.BTPServiceOperatorConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("BTPServiceOperator"),
 				hasAvailableVersionsError(errFake),
@@ -90,7 +86,7 @@ func Test_BTPServiceOperator(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &BTPServiceOperator{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/btpso_component_test.go
+++ b/pkg/controlplane/components/btpso_component_test.go
@@ -14,7 +14,7 @@ func Test_BTPServiceOperator(t *testing.T) {
 		desc             string
 		config           *v1beta1.BTPServiceOperatorConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_BTPServiceOperator(t *testing.T) {
 			config: &v1beta1.BTPServiceOperatorConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("BTPServiceOperator"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_BTPServiceOperator(t *testing.T) {
 			config: &v1beta1.BTPServiceOperatorConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("BTPServiceOperator"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/cert_manager_component.go
+++ b/pkg/controlplane/components/cert_manager_component.go
@@ -45,6 +45,11 @@ func (c *CertManager) IsInstallable(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (c *CertManager) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(certManagerRelease)
+}
+
 func (c *CertManager) BuildSourceRepository(ctx context.Context) (fluxcd.SourceAdapter, error) {
 	rfn := rcontext.VersionResolver(ctx)
 	c.applyDefaultChartSpec(rfn)

--- a/pkg/controlplane/components/cert_manager_component.go
+++ b/pkg/controlplane/components/cert_manager_component.go
@@ -39,6 +39,9 @@ func (c *CertManager) GetNamespace() string {
 
 func (c *CertManager) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(certManagerRelease, c.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/cert_manager_component.go
+++ b/pkg/controlplane/components/cert_manager_component.go
@@ -46,7 +46,7 @@ func (c *CertManager) IsInstallable(ctx context.Context) (bool, error) {
 }
 
 func (c *CertManager) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(certManagerRelease)
 }
 

--- a/pkg/controlplane/components/cert_manager_component_test.go
+++ b/pkg/controlplane/components/cert_manager_component_test.go
@@ -14,7 +14,7 @@ func Test_CertManager(t *testing.T) {
 		desc             string
 		config           *v1beta1.CertManagerConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_CertManager(t *testing.T) {
 			config: &v1beta1.CertManagerConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("CertManager"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_CertManager(t *testing.T) {
 			config: &v1beta1.CertManagerConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("CertManager"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/cert_manager_component_test.go
+++ b/pkg/controlplane/components/cert_manager_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_CertManager(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.CertManagerConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.CertManagerConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_CertManager(t *testing.T) {
 				hasName("CertManager"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.CertManagerConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("CertManager"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.CertManagerConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("CertManager"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -64,7 +87,7 @@ func Test_CertManager(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &CertManager{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/cert_manager_component_test.go
+++ b/pkg/controlplane/components/cert_manager_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_CertManager(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.CertManagerConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.CertManagerConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_CertManager(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.CertManagerConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.CertManagerConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("CertManager"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.CertManagerConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.CertManagerConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("CertManager"),
 				hasAvailableVersionsError(errFake),
@@ -87,7 +83,7 @@ func Test_CertManager(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &CertManager{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/clusterrole_component_test.go
+++ b/pkg/controlplane/components/clusterrole_component_test.go
@@ -97,7 +97,7 @@ func Test_ClusterRole(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, nil)
+			ctx := newContext(nil, nil, nil)
 			c := &ClusterRole{Name: tC.name, Rules: tC.rules, Enabled: tC.enabled}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/common.go
+++ b/pkg/controlplane/components/common.go
@@ -1,10 +1,14 @@
 package components
 
 import (
+	"errors"
+
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/openmcp-project/control-plane-operator/pkg/juggler"
 )
+
+var ErrVersionResolverNotConfigured = errors.New("version resolver is not configured in context")
 
 // TargetComponent is a component that should be installed on the Target (remote/workload) cluster.
 type TargetComponent interface {

--- a/pkg/controlplane/components/crossplane_component.go
+++ b/pkg/controlplane/components/crossplane_component.go
@@ -101,6 +101,9 @@ func (c *Crossplane) GetNamespace() string {
 
 func (c *Crossplane) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(crossplaneRelease, c.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/crossplane_component.go
+++ b/pkg/controlplane/components/crossplane_component.go
@@ -107,6 +107,11 @@ func (c *Crossplane) IsInstallable(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (c *Crossplane) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(crossplaneRelease)
+}
+
 func (c *Crossplane) BuildSourceRepository(ctx context.Context) (fluxcd.SourceAdapter, error) {
 	rfn := rcontext.VersionResolver(ctx)
 	c.applyDefaultChartSpec(rfn)

--- a/pkg/controlplane/components/crossplane_component.go
+++ b/pkg/controlplane/components/crossplane_component.go
@@ -108,7 +108,7 @@ func (c *Crossplane) IsInstallable(ctx context.Context) (bool, error) {
 }
 
 func (c *Crossplane) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(crossplaneRelease)
 }
 

--- a/pkg/controlplane/components/crossplane_component_test.go
+++ b/pkg/controlplane/components/crossplane_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_Crossplane(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.CrossplaneConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.CrossplaneConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_Crossplane(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.CrossplaneConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.CrossplaneConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Crossplane"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.CrossplaneConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.CrossplaneConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Crossplane"),
 				hasAvailableVersionsError(errFake),
@@ -86,7 +82,7 @@ func Test_Crossplane(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &Crossplane{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/crossplane_component_test.go
+++ b/pkg/controlplane/components/crossplane_component_test.go
@@ -14,7 +14,7 @@ func Test_Crossplane(t *testing.T) {
 		desc             string
 		config           *v1beta1.CrossplaneConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_Crossplane(t *testing.T) {
 			config: &v1beta1.CrossplaneConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Crossplane"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_Crossplane(t *testing.T) {
 			config: &v1beta1.CrossplaneConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Crossplane"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/crossplane_component_test.go
+++ b/pkg/controlplane/components/crossplane_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_Crossplane(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.CrossplaneConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.CrossplaneConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_Crossplane(t *testing.T) {
 				hasName("Crossplane"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.CrossplaneConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("Crossplane"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.CrossplaneConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("Crossplane"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -63,7 +86,7 @@ func Test_Crossplane(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &Crossplane{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/crossplaneprovider_component.go
+++ b/pkg/controlplane/components/crossplaneprovider_component.go
@@ -119,7 +119,7 @@ func (c *CrossplaneProvider) IsInstallable(ctx context.Context) (bool, error) {
 
 // GetAvailableVersions implements Component.
 func (c *CrossplaneProvider) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(crossplane.ProviderNameForProviderConfig(c.Config))
 }
 

--- a/pkg/controlplane/components/crossplaneprovider_component.go
+++ b/pkg/controlplane/components/crossplaneprovider_component.go
@@ -111,6 +111,9 @@ func (c *CrossplaneProvider) GetNamespace() string {
 // IsInstallable implements Component.
 func (c *CrossplaneProvider) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(crossplane.ProviderNameForProviderConfig(c.Config), c.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/crossplaneprovider_component.go
+++ b/pkg/controlplane/components/crossplaneprovider_component.go
@@ -117,6 +117,12 @@ func (c *CrossplaneProvider) IsInstallable(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+// GetAvailableVersions implements Component.
+func (c *CrossplaneProvider) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(crossplane.ProviderNameForProviderConfig(c.Config))
+}
+
 // GetName implements Component.
 func (c *CrossplaneProvider) GetName() string {
 	return formatProviderName(c.Config.Name)

--- a/pkg/controlplane/components/crossplaneprovider_component_test.go
+++ b/pkg/controlplane/components/crossplaneprovider_component_test.go
@@ -102,13 +102,13 @@ func Test_formatProviderName(t *testing.T) {
 
 func Test_CrossplaneProvider(t *testing.T) {
 	testCases := []struct {
-		desc              string
-		enabled           bool
-		config            *v1beta1.CrossplaneProviderConfig
-		versionResolver   v1beta1.VersionResolverFn
-		versionsResolver  v1beta1.AvailableVersionsResolverFn
-		secretRefResolver secretresolver.ResolveFunc
-		validationFuncs   []validationFunc
+		desc                      string
+		enabled                   bool
+		config                    *v1beta1.CrossplaneProviderConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		secretRefResolver         secretresolver.ResolveFunc
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc:    "should be disabled",
@@ -172,7 +172,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 			config: &v1beta1.CrossplaneProviderConfig{
 				Name: "kubernetes",
 			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
@@ -183,7 +183,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 			config: &v1beta1.CrossplaneProviderConfig{
 				Name: "kubernetes",
 			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasAvailableVersionsError(errFake),
 			},
@@ -240,7 +240,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(tC.secretRefResolver, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(tC.secretRefResolver, tC.versionResolver, tC.availableVersionsResolver)
 			c := &CrossplaneProvider{Config: tC.config, Enabled: tC.enabled}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/crossplaneprovider_component_test.go
+++ b/pkg/controlplane/components/crossplaneprovider_component_test.go
@@ -106,6 +106,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 		enabled           bool
 		config            *v1beta1.CrossplaneProviderConfig
 		versionResolver   v1beta1.VersionResolverFn
+		versionsResolver  v1beta1.VersionsResolverFn
 		secretRefResolver secretresolver.ResolveFunc
 		validationFuncs   []validationFunc
 	}{
@@ -166,6 +167,28 @@ func Test_CrossplaneProvider(t *testing.T) {
 			},
 		},
 		{
+			desc:    "returns available versions from context resolver",
+			enabled: true,
+			config: &v1beta1.CrossplaneProviderConfig{
+				Name: "kubernetes",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc:    "returns error when available versions resolver fails",
+			enabled: true,
+			config: &v1beta1.CrossplaneProviderConfig{
+				Name: "kubernetes",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasAvailableVersionsError(errFake),
+			},
+		},
+		{
 			desc:    "should be enabled",
 			enabled: true,
 			config: &v1beta1.CrossplaneProviderConfig{
@@ -217,7 +240,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(tC.secretRefResolver, tC.versionResolver)
+			ctx := newContext(tC.secretRefResolver, tC.versionResolver, tC.versionsResolver)
 			c := &CrossplaneProvider{Config: tC.config, Enabled: tC.enabled}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/crossplaneprovider_component_test.go
+++ b/pkg/controlplane/components/crossplaneprovider_component_test.go
@@ -106,7 +106,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 		enabled           bool
 		config            *v1beta1.CrossplaneProviderConfig
 		versionResolver   v1beta1.VersionResolverFn
-		versionsResolver  v1beta1.VersionsResolverFn
+		versionsResolver  v1beta1.AvailableVersionsResolverFn
 		secretRefResolver secretresolver.ResolveFunc
 		validationFuncs   []validationFunc
 	}{
@@ -172,7 +172,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 			config: &v1beta1.CrossplaneProviderConfig{
 				Name: "kubernetes",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
@@ -183,7 +183,7 @@ func Test_CrossplaneProvider(t *testing.T) {
 			config: &v1beta1.CrossplaneProviderConfig{
 				Name: "kubernetes",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasAvailableVersionsError(errFake),
 			},

--- a/pkg/controlplane/components/eso_component.go
+++ b/pkg/controlplane/components/eso_component.go
@@ -120,7 +120,7 @@ func (e *ExternalSecretsOperator) IsInstallable(ctx context.Context) (bool, erro
 }
 
 func (e *ExternalSecretsOperator) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(esoRelease)
 }
 

--- a/pkg/controlplane/components/eso_component.go
+++ b/pkg/controlplane/components/eso_component.go
@@ -113,6 +113,9 @@ func (e *ExternalSecretsOperator) GetNamespace() string {
 
 func (e *ExternalSecretsOperator) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(esoRelease, e.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/eso_component.go
+++ b/pkg/controlplane/components/eso_component.go
@@ -119,6 +119,11 @@ func (e *ExternalSecretsOperator) IsInstallable(ctx context.Context) (bool, erro
 	return true, nil
 }
 
+func (e *ExternalSecretsOperator) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(esoRelease)
+}
+
 func (e *ExternalSecretsOperator) BuildSourceRepository(ctx context.Context) (fluxcd.SourceAdapter, error) {
 	rfn := rcontext.VersionResolver(ctx)
 	e.applyDefaultChartSpec(rfn)

--- a/pkg/controlplane/components/eso_component_test.go
+++ b/pkg/controlplane/components/eso_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_ExternalSecretsOperator(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.ExternalSecretsOperatorConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.ExternalSecretsOperatorConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 				hasName("ExternalSecretsOperator"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.ExternalSecretsOperatorConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("ExternalSecretsOperator"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.ExternalSecretsOperatorConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("ExternalSecretsOperator"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -66,7 +89,7 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &ExternalSecretsOperator{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/eso_component_test.go
+++ b/pkg/controlplane/components/eso_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_ExternalSecretsOperator(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.ExternalSecretsOperatorConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.ExternalSecretsOperatorConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.ExternalSecretsOperatorConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.ExternalSecretsOperatorConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("ExternalSecretsOperator"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.ExternalSecretsOperatorConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.ExternalSecretsOperatorConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("ExternalSecretsOperator"),
 				hasAvailableVersionsError(errFake),
@@ -89,7 +85,7 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &ExternalSecretsOperator{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/eso_component_test.go
+++ b/pkg/controlplane/components/eso_component_test.go
@@ -14,7 +14,7 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 		desc             string
 		config           *v1beta1.ExternalSecretsOperatorConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 			config: &v1beta1.ExternalSecretsOperatorConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("ExternalSecretsOperator"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_ExternalSecretsOperator(t *testing.T) {
 			config: &v1beta1.ExternalSecretsOperatorConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("ExternalSecretsOperator"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/flux_component.go
+++ b/pkg/controlplane/components/flux_component.go
@@ -100,7 +100,7 @@ func (f *Flux) IsInstallable(ctx context.Context) (bool, error) {
 }
 
 func (f *Flux) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(fluxRelease)
 }
 

--- a/pkg/controlplane/components/flux_component.go
+++ b/pkg/controlplane/components/flux_component.go
@@ -93,6 +93,9 @@ func (f *Flux) Hooks() juggler.ComponentHooks {
 
 func (f *Flux) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(fluxRelease, f.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/flux_component.go
+++ b/pkg/controlplane/components/flux_component.go
@@ -99,6 +99,11 @@ func (f *Flux) IsInstallable(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (f *Flux) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(fluxRelease)
+}
+
 func (f *Flux) applyDefaultChartSpec(rfn v1beta1.VersionResolverFn) {
 	if f.Config == nil {
 		f.Config = &v1beta1.FluxConfig{}

--- a/pkg/controlplane/components/flux_component_test.go
+++ b/pkg/controlplane/components/flux_component_test.go
@@ -14,7 +14,7 @@ func Test_Flux(t *testing.T) {
 		desc             string
 		config           *v1beta1.FluxConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_Flux(t *testing.T) {
 			config: &v1beta1.FluxConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Flux"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_Flux(t *testing.T) {
 			config: &v1beta1.FluxConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Flux"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/flux_component_test.go
+++ b/pkg/controlplane/components/flux_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_Flux(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.FluxConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.FluxConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_Flux(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.FluxConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.FluxConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Flux"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.FluxConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.FluxConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Flux"),
 				hasAvailableVersionsError(errFake),
@@ -89,7 +85,7 @@ func Test_Flux(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &Flux{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/flux_component_test.go
+++ b/pkg/controlplane/components/flux_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_Flux(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.FluxConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.FluxConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_Flux(t *testing.T) {
 				hasName("Flux"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.FluxConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("Flux"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.FluxConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("Flux"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -66,7 +89,7 @@ func Test_Flux(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &Flux{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/generic_object_component_test.go
+++ b/pkg/controlplane/components/generic_object_component_test.go
@@ -105,7 +105,7 @@ func Test_GenericObjectComponent(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, nil)
+			ctx := newContext(nil, nil, nil)
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, tC.comp)
 			}

--- a/pkg/controlplane/components/kyverno_component.go
+++ b/pkg/controlplane/components/kyverno_component.go
@@ -165,7 +165,7 @@ func (k *Kyverno) IsInstallable(ctx context.Context) (bool, error) {
 }
 
 func (k *Kyverno) GetAvailableVersions(ctx context.Context) ([]string, error) {
-	resolve := rcontext.VersionsResolver(ctx)
+	resolve := rcontext.AvailableVersionsResolver(ctx)
 	return resolve(kyvernoRelease)
 }
 

--- a/pkg/controlplane/components/kyverno_component.go
+++ b/pkg/controlplane/components/kyverno_component.go
@@ -164,6 +164,11 @@ func (k *Kyverno) IsInstallable(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+func (k *Kyverno) GetAvailableVersions(ctx context.Context) ([]string, error) {
+	resolve := rcontext.VersionsResolver(ctx)
+	return resolve(kyvernoRelease)
+}
+
 func (k *Kyverno) BuildSourceRepository(ctx context.Context) (fluxcd.SourceAdapter, error) {
 	rfn := rcontext.VersionResolver(ctx)
 	k.applyDefaultChartSpec(rfn)

--- a/pkg/controlplane/components/kyverno_component.go
+++ b/pkg/controlplane/components/kyverno_component.go
@@ -158,6 +158,9 @@ func (k *Kyverno) Hooks() juggler.ComponentHooks {
 
 func (k *Kyverno) IsInstallable(ctx context.Context) (bool, error) {
 	rfn := rcontext.VersionResolver(ctx)
+	if rfn == nil {
+		return false, ErrVersionResolverNotConfigured
+	}
 	if _, err := rfn(kyvernoRelease, k.Config.Version); err != nil {
 		return false, err
 	}

--- a/pkg/controlplane/components/kyverno_component_test.go
+++ b/pkg/controlplane/components/kyverno_component_test.go
@@ -11,11 +11,11 @@ import (
 
 func Test_Kyverno(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		config           *v1beta1.KyvernoConfig
-		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.AvailableVersionsResolverFn
-		validationFuncs  []validationFunc
+		desc                      string
+		config                    *v1beta1.KyvernoConfig
+		versionResolver           v1beta1.VersionResolverFn
+		availableVersionsResolver v1beta1.AvailableVersionsResolverFn
+		validationFuncs           []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -37,22 +37,18 @@ func Test_Kyverno(t *testing.T) {
 			},
 		},
 		{
-			desc: "returns available versions from context resolver",
-			config: &v1beta1.KyvernoConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(false),
+			desc:                      "returns available versions from context resolver",
+			config:                    &v1beta1.KyvernoConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Kyverno"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
 			},
 		},
 		{
-			desc: "returns error when available versions resolver fails",
-			config: &v1beta1.KyvernoConfig{
-				Version: "1.2.3",
-			},
-			versionsResolver: fakeAvailableVersionsResolver(true),
+			desc:                      "returns error when available versions resolver fails",
+			config:                    &v1beta1.KyvernoConfig{},
+			availableVersionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Kyverno"),
 				hasAvailableVersionsError(errFake),
@@ -89,7 +85,7 @@ func Test_Kyverno(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.availableVersionsResolver)
 			c := &Kyverno{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/kyverno_component_test.go
+++ b/pkg/controlplane/components/kyverno_component_test.go
@@ -14,7 +14,7 @@ func Test_Kyverno(t *testing.T) {
 		desc             string
 		config           *v1beta1.KyvernoConfig
 		versionResolver  v1beta1.VersionResolverFn
-		versionsResolver v1beta1.VersionsResolverFn
+		versionsResolver v1beta1.AvailableVersionsResolverFn
 		validationFuncs  []validationFunc
 	}{
 		{
@@ -41,7 +41,7 @@ func Test_Kyverno(t *testing.T) {
 			config: &v1beta1.KyvernoConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(false),
+			versionsResolver: fakeAvailableVersionsResolver(false),
 			validationFuncs: []validationFunc{
 				hasName("Kyverno"),
 				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
@@ -52,7 +52,7 @@ func Test_Kyverno(t *testing.T) {
 			config: &v1beta1.KyvernoConfig{
 				Version: "1.2.3",
 			},
-			versionsResolver: fakeVersionsResolver(true),
+			versionsResolver: fakeAvailableVersionsResolver(true),
 			validationFuncs: []validationFunc{
 				hasName("Kyverno"),
 				hasAvailableVersionsError(errFake),

--- a/pkg/controlplane/components/kyverno_component_test.go
+++ b/pkg/controlplane/components/kyverno_component_test.go
@@ -11,10 +11,11 @@ import (
 
 func Test_Kyverno(t *testing.T) {
 	testCases := []struct {
-		desc            string
-		config          *v1beta1.KyvernoConfig
-		versionResolver v1beta1.VersionResolverFn
-		validationFuncs []validationFunc
+		desc             string
+		config           *v1beta1.KyvernoConfig
+		versionResolver  v1beta1.VersionResolverFn
+		versionsResolver v1beta1.VersionsResolverFn
+		validationFuncs  []validationFunc
 	}{
 		{
 			desc: "should be disabled",
@@ -33,6 +34,28 @@ func Test_Kyverno(t *testing.T) {
 				hasName("Kyverno"),
 				isEnabled(true),
 				isAllowed(false),
+			},
+		},
+		{
+			desc: "returns available versions from context resolver",
+			config: &v1beta1.KyvernoConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(false),
+			validationFuncs: []validationFunc{
+				hasName("Kyverno"),
+				hasAvailableVersions([]string{"1.1.0", "1.2.0"}),
+			},
+		},
+		{
+			desc: "returns error when available versions resolver fails",
+			config: &v1beta1.KyvernoConfig{
+				Version: "1.2.3",
+			},
+			versionsResolver: fakeVersionsResolver(true),
+			validationFuncs: []validationFunc{
+				hasName("Kyverno"),
+				hasAvailableVersionsError(errFake),
 			},
 		},
 		{
@@ -66,7 +89,7 @@ func Test_Kyverno(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, tC.versionResolver)
+			ctx := newContext(nil, tC.versionResolver, tC.versionsResolver)
 			c := &Kyverno{Config: tC.config}
 			for _, vfn := range tC.validationFuncs {
 				vfn(t, ctx, c)

--- a/pkg/controlplane/components/secret_component_test.go
+++ b/pkg/controlplane/components/secret_component_test.go
@@ -158,7 +158,7 @@ func Test_Secret(t *testing.T) {
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			ctx := newContext(nil, nil)
+			ctx := newContext(nil, nil, nil)
 			fakeClient := fake.NewClientBuilder().WithInterceptorFuncs(tC.interceptorFuncs).WithObjects(sourceSecret).Build()
 			c := &Secret{
 				Enabled:      tC.enabled,

--- a/pkg/controlplane/components/utils_test.go
+++ b/pkg/controlplane/components/utils_test.go
@@ -42,7 +42,7 @@ func fakeVersionResolver(shouldFail bool) v1beta1.VersionResolverFn {
 	}
 }
 
-func fakeVersionsResolver(shouldFail bool) v1beta1.VersionsResolverFn {
+func fakeAvailableVersionsResolver(shouldFail bool) v1beta1.AvailableVersionsResolverFn {
 	return func(componentName string) ([]string, error) {
 		if shouldFail {
 			return nil, errFake
@@ -138,13 +138,13 @@ func hasAvailableVersionsError(expected error) validationFunc {
 	}
 }
 
-func newContext(fn secretresolver.ResolveFunc, fn2 v1beta1.VersionResolverFn, fn3 v1beta1.VersionsResolverFn) context.Context {
+func newContext(fn secretresolver.ResolveFunc, fn2 v1beta1.VersionResolverFn, fn3 v1beta1.AvailableVersionsResolverFn) context.Context {
 	ctx := context.Background()
 	ctx = rcontext.WithTenantNamespace(ctx, tenantNamespace)
 	ctx = rcontext.WithFluxKubeconfigRef(ctx, &corev1.SecretReference{Name: fluxSecretRef.SecretRef.Name})
 	ctx = rcontext.WithSecretRefResolver(ctx, fn)
 	ctx = rcontext.WithVersionResolver(ctx, fn2)
-	ctx = rcontext.WithVersionsResolver(ctx, fn3)
+	ctx = rcontext.WithAvailableVersionsResolver(ctx, fn3)
 	return ctx
 }
 

--- a/pkg/controlplane/components/utils_test.go
+++ b/pkg/controlplane/components/utils_test.go
@@ -42,6 +42,15 @@ func fakeVersionResolver(shouldFail bool) v1beta1.VersionResolverFn {
 	}
 }
 
+func fakeVersionsResolver(shouldFail bool) v1beta1.VersionsResolverFn {
+	return func(componentName string) ([]string, error) {
+		if shouldFail {
+			return nil, errFake
+		}
+		return []string{"1.1.0", "1.2.0"}, nil
+	}
+}
+
 func fakeSecretRefResolver(shouldFail, shouldReturn bool) secretresolver.ResolveFunc {
 	return func(urlType secretresolver.UrlSecretType) (*corev1.LocalObjectReference, error) {
 		if shouldFail {
@@ -111,12 +120,31 @@ func hasDependencies(count int) validationFunc {
 	}
 }
 
-func newContext(fn secretresolver.ResolveFunc, fn2 v1beta1.VersionResolverFn) context.Context {
+func hasAvailableVersions(expected []string) validationFunc {
+	return func(t *testing.T, ctx context.Context, c juggler.Component) {
+		gv := c.(juggler.GetAvailableVersions)
+		versions, err := gv.GetAvailableVersions(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, versions)
+	}
+}
+
+func hasAvailableVersionsError(expected error) validationFunc {
+	return func(t *testing.T, ctx context.Context, c juggler.Component) {
+		gv := c.(juggler.GetAvailableVersions)
+		versions, err := gv.GetAvailableVersions(ctx)
+		assert.ErrorIs(t, err, expected)
+		assert.Nil(t, versions)
+	}
+}
+
+func newContext(fn secretresolver.ResolveFunc, fn2 v1beta1.VersionResolverFn, fn3 v1beta1.VersionsResolverFn) context.Context {
 	ctx := context.Background()
 	ctx = rcontext.WithTenantNamespace(ctx, tenantNamespace)
 	ctx = rcontext.WithFluxKubeconfigRef(ctx, &corev1.SecretReference{Name: fluxSecretRef.SecretRef.Name})
 	ctx = rcontext.WithSecretRefResolver(ctx, fn)
 	ctx = rcontext.WithVersionResolver(ctx, fn2)
+	ctx = rcontext.WithVersionsResolver(ctx, fn3)
 	return ctx
 }
 

--- a/pkg/juggler/component.go
+++ b/pkg/juggler/component.go
@@ -56,6 +56,11 @@ type KeepOnUninstall interface {
 	KeepOnUninstall() bool
 }
 
+// GetAvailableVersions can be implemented by components that need a release-channel version lookup.
+type GetAvailableVersions interface {
+	GetAvailableVersions(ctx context.Context) ([]string, error)
+}
+
 // ComponentStatus indicates the status of a component.
 type ComponentStatus struct {
 	Name       string

--- a/pkg/juggler/fakes_test.go
+++ b/pkg/juggler/fakes_test.go
@@ -91,6 +91,25 @@ func (f FakeComponent2) Hooks() ComponentHooks {
 
 // ---------------------------------------------------------------------------------------------------
 
+var _ Component = FakeComponent3{}
+
+type FakeComponent3 struct {
+	FakeComponent
+	InstallableErr error
+	Versions       []string
+	VersionsErr    error
+}
+
+func (f FakeComponent3) IsInstallable(context.Context) (bool, error) {
+	return false, f.InstallableErr
+}
+
+func (f FakeComponent3) GetAvailableVersions(context.Context) ([]string, error) {
+	return f.Versions, f.VersionsErr
+}
+
+// ---------------------------------------------------------------------------------------------------
+
 var _ ComponentReconciler = FakeReconciler{}
 var _ OrphanedComponentsDetector = FakeReconciler{}
 

--- a/pkg/juggler/juggler.go
+++ b/pkg/juggler/juggler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/openmcp-project/control-plane-operator/internal/ocm"
 	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 )
 
@@ -150,7 +151,7 @@ func (am *Juggler) reconcileComponent(ctx context.Context, component Component) 
 	}
 
 	is, err := component.IsInstallable(ctx)
-	if observation.ResourceExists && err != nil {
+	if observation.ResourceExists && errors.Is(err, ocm.ErrComponentVersionNotFound) {
 		message := fmt.Sprintf("%s is installed but current version is not in release channel", component.GetName())
 		message = am.appendAvailableVersionsToMessage(ctx, component, message)
 		return ComponentResult{

--- a/pkg/juggler/juggler.go
+++ b/pkg/juggler/juggler.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
+
+	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 )
 
 var (
@@ -147,6 +150,15 @@ func (am *Juggler) reconcileComponent(ctx context.Context, component Component) 
 	}
 
 	is, err := component.IsInstallable(ctx)
+	if observation.ResourceExists && err != nil {
+		message := fmt.Sprintf("%s is installed but current version is not in release channel", component.GetName())
+		message = am.appendAvailableVersionsToMessage(ctx, component, message)
+		return ComponentResult{
+			Component: component,
+			Result:    StatusHealthy,
+			Message:   message,
+		}
+	}
 	if err != nil {
 		return ComponentResult{
 			Component: component,
@@ -292,4 +304,22 @@ func (am *Juggler) componentsOfReconciler(r ComponentReconciler) []Component {
 		}
 	}
 	return configuredComponents
+}
+
+func (am *Juggler) appendAvailableVersionsToMessage(ctx context.Context, component Component, message string) string {
+	if rcontext.VersionsResolver(ctx) == nil {
+		return message
+	}
+
+	gv, ok := component.(GetAvailableVersions)
+	if !ok {
+		return message
+	}
+
+	versions, err := gv.GetAvailableVersions(ctx)
+	if err != nil {
+		return fmt.Sprintf("%s: available versions: %s", message, err)
+	}
+
+	return fmt.Sprintf("%s: available versions: %s", message, strings.Join(versions, ", "))
 }

--- a/pkg/juggler/juggler.go
+++ b/pkg/juggler/juggler.go
@@ -307,7 +307,7 @@ func (am *Juggler) componentsOfReconciler(r ComponentReconciler) []Component {
 }
 
 func (am *Juggler) appendAvailableVersionsToMessage(ctx context.Context, component Component, message string) string {
-	if rcontext.VersionsResolver(ctx) == nil {
+	if rcontext.AvailableVersionsResolver(ctx) == nil {
 		return message
 	}
 

--- a/pkg/juggler/juggler_test.go
+++ b/pkg/juggler/juggler_test.go
@@ -601,7 +601,7 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 				object:   &cp,
 			})
 			am.RegisterReconciler(tt.args.reconciler)
-			ctx := rcontext.WithVersionsResolver(context.TODO(), func(componentName string) ([]string, error) {
+			ctx := rcontext.WithAvailableVersionsResolver(context.TODO(), func(componentName string) ([]string, error) {
 				return nil, nil
 			})
 			result := am.reconcileComponent(ctx, tt.args.component)

--- a/pkg/juggler/juggler_test.go
+++ b/pkg/juggler/juggler_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/client-go/tools/events"
 
 	"github.com/openmcp-project/control-plane-operator/api/v1beta1"
+	"github.com/openmcp-project/control-plane-operator/internal/ocm"
 	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 
 	"github.com/go-logr/logr"
@@ -546,7 +547,7 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 			args: args{
 				component: FakeComponent3{
 					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
-					InstallableErr: errBoom,
+					InstallableErr: ocm.ErrComponentVersionNotFound,
 					Versions:       []string{"1.1.0", "1.2.0"},
 				},
 				reconciler: FakeReconciler{
@@ -559,7 +560,7 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 			want: ComponentResult{
 				Component: FakeComponent3{
 					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
-					InstallableErr: errBoom,
+					InstallableErr: ocm.ErrComponentVersionNotFound,
 					Versions:       []string{"1.1.0", "1.2.0"},
 				},
 				Result:  StatusHealthy,
@@ -571,7 +572,7 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 			args: args{
 				component: FakeComponent3{
 					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
-					InstallableErr: errBoom,
+					InstallableErr: ocm.ErrComponentVersionNotFound,
 					VersionsErr:    errBoom,
 				},
 				reconciler: FakeReconciler{
@@ -584,7 +585,7 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 			want: ComponentResult{
 				Component: FakeComponent3{
 					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
-					InstallableErr: errBoom,
+					InstallableErr: ocm.ErrComponentVersionNotFound,
 					VersionsErr:    errBoom,
 				},
 				Result:  StatusHealthy,

--- a/pkg/juggler/juggler_test.go
+++ b/pkg/juggler/juggler_test.go
@@ -3,12 +3,14 @@ package juggler
 import (
 	"context"
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
 	"k8s.io/client-go/tools/events"
 
 	"github.com/openmcp-project/control-plane-operator/api/v1beta1"
+	"github.com/openmcp-project/control-plane-operator/pkg/utils/rcontext"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
@@ -247,6 +249,7 @@ func knowsAll() func() []reflect.Type {
 		return []reflect.Type{
 			reflect.TypeOf(FakeComponent{}),
 			reflect.TypeOf(FakeComponent2{}),
+			reflect.TypeOf(FakeComponent3{}),
 		}
 	}
 }
@@ -538,6 +541,56 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 				Message:   "not healthy",
 			},
 		},
+		{
+			name: "component exists but not installable",
+			args: args{
+				component: FakeComponent3{
+					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
+					InstallableErr: errBoom,
+					Versions:       []string{"1.1.0", "1.2.0"},
+				},
+				reconciler: FakeReconciler{
+					KnownTypesFunc: knowsAll(),
+					ObserverFunc: func(ctx context.Context, component Component) (ComponentObservation, error) {
+						return ComponentObservation{ResourceExists: true}, nil
+					},
+				},
+			},
+			want: ComponentResult{
+				Component: FakeComponent3{
+					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
+					InstallableErr: errBoom,
+					Versions:       []string{"1.1.0", "1.2.0"},
+				},
+				Result:  StatusHealthy,
+				Message: "FakeComponent is installed but current version is not in release channel: available versions: 1.1.0, 1.2.0",
+			},
+		},
+		{
+			name: "component exists but not installable, no versions found",
+			args: args{
+				component: FakeComponent3{
+					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
+					InstallableErr: errBoom,
+					VersionsErr:    errBoom,
+				},
+				reconciler: FakeReconciler{
+					KnownTypesFunc: knowsAll(),
+					ObserverFunc: func(ctx context.Context, component Component) (ComponentObservation, error) {
+						return ComponentObservation{ResourceExists: true}, nil
+					},
+				},
+			},
+			want: ComponentResult{
+				Component: FakeComponent3{
+					FakeComponent:  FakeComponent{Enabled: true, Allowed: true},
+					InstallableErr: errBoom,
+					VersionsErr:    errBoom,
+				},
+				Result:  StatusHealthy,
+				Message: fmt.Sprintf("FakeComponent is installed but current version is not in release channel: available versions: %s", errBoom),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -548,7 +601,10 @@ func TestJuggler_reconcileComponent(t *testing.T) {
 				object:   &cp,
 			})
 			am.RegisterReconciler(tt.args.reconciler)
-			result := am.reconcileComponent(context.TODO(), tt.args.component)
+			ctx := rcontext.WithVersionsResolver(context.TODO(), func(componentName string) ([]string, error) {
+				return nil, nil
+			})
+			result := am.reconcileComponent(ctx, tt.args.component)
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/utils/rcontext/rcontext.go
+++ b/pkg/utils/rcontext/rcontext.go
@@ -55,11 +55,13 @@ func WithAvailableVersionsResolver(ctx context.Context, fn v1beta1.AvailableVers
 }
 
 func VersionResolver(ctx context.Context) v1beta1.VersionResolverFn {
-	return ctx.Value(versionResolverFnKey{}).(v1beta1.VersionResolverFn)
+	fn, _ := ctx.Value(versionResolverFnKey{}).(v1beta1.VersionResolverFn)
+	return fn
 }
 
 func AvailableVersionsResolver(ctx context.Context) v1beta1.AvailableVersionsResolverFn {
-	return ctx.Value(availableVersionsResolverFnKey{}).(v1beta1.AvailableVersionsResolverFn)
+	fn, _ := ctx.Value(availableVersionsResolverFnKey{}).(v1beta1.AvailableVersionsResolverFn)
+	return fn
 }
 
 //
@@ -73,5 +75,6 @@ func WithSecretRefResolver(ctx context.Context, fn secretresolver.ResolveFunc) c
 }
 
 func SecretRefResolver(ctx context.Context) secretresolver.ResolveFunc {
-	return ctx.Value(secretRefResolverFnKey{}).(secretresolver.ResolveFunc)
+	fn, _ := ctx.Value(secretRefResolverFnKey{}).(secretresolver.ResolveFunc)
+	return fn
 }

--- a/pkg/utils/rcontext/rcontext.go
+++ b/pkg/utils/rcontext/rcontext.go
@@ -44,22 +44,22 @@ func FluxKubeconfigRef(ctx context.Context) *meta.KubeConfigReference {
 //
 
 type versionResolverFnKey struct{}
-type versionsResolverFnKey struct{}
+type availableVersionsResolverFnKey struct{}
 
 func WithVersionResolver(ctx context.Context, fn v1beta1.VersionResolverFn) context.Context {
 	return context.WithValue(ctx, versionResolverFnKey{}, fn)
 }
 
-func WithVersionsResolver(ctx context.Context, fn v1beta1.VersionsResolverFn) context.Context {
-	return context.WithValue(ctx, versionsResolverFnKey{}, fn)
+func WithAvailableVersionsResolver(ctx context.Context, fn v1beta1.AvailableVersionsResolverFn) context.Context {
+	return context.WithValue(ctx, availableVersionsResolverFnKey{}, fn)
 }
 
 func VersionResolver(ctx context.Context) v1beta1.VersionResolverFn {
 	return ctx.Value(versionResolverFnKey{}).(v1beta1.VersionResolverFn)
 }
 
-func VersionsResolver(ctx context.Context) v1beta1.VersionsResolverFn {
-	return ctx.Value(versionsResolverFnKey{}).(v1beta1.VersionsResolverFn)
+func AvailableVersionsResolver(ctx context.Context) v1beta1.AvailableVersionsResolverFn {
+	return ctx.Value(availableVersionsResolverFnKey{}).(v1beta1.AvailableVersionsResolverFn)
 }
 
 //

--- a/pkg/utils/rcontext/rcontext.go
+++ b/pkg/utils/rcontext/rcontext.go
@@ -44,13 +44,22 @@ func FluxKubeconfigRef(ctx context.Context) *meta.KubeConfigReference {
 //
 
 type versionResolverFnKey struct{}
+type versionsResolverFnKey struct{}
 
 func WithVersionResolver(ctx context.Context, fn v1beta1.VersionResolverFn) context.Context {
 	return context.WithValue(ctx, versionResolverFnKey{}, fn)
 }
 
+func WithVersionsResolver(ctx context.Context, fn v1beta1.VersionsResolverFn) context.Context {
+	return context.WithValue(ctx, versionsResolverFnKey{}, fn)
+}
+
 func VersionResolver(ctx context.Context) v1beta1.VersionResolverFn {
 	return ctx.Value(versionResolverFnKey{}).(v1beta1.VersionResolverFn)
+}
+
+func VersionsResolver(ctx context.Context) v1beta1.VersionsResolverFn {
+	return ctx.Value(versionsResolverFnKey{}).(v1beta1.VersionsResolverFn)
 }
 
 //

--- a/pkg/utils/rcontext/rcontext_test.go
+++ b/pkg/utils/rcontext/rcontext_test.go
@@ -38,6 +38,17 @@ func TestWithVersionResolver(t *testing.T) {
 	}
 }
 
+func TestWithVersionsResolver(t *testing.T) {
+	fn := func(componentName string) ([]string, error) {
+		return []string{"1.0.0"}, nil
+	}
+	ctx := WithVersionsResolver(context.TODO(), fn)
+	actual := VersionsResolver(ctx)
+	if reflect.ValueOf(actual).Pointer() != reflect.ValueOf(fn).Pointer() {
+		t.Error("Functions are not equal")
+	}
+}
+
 func TestSecretRefResolver(t *testing.T) {
 	fn := func(urlType secretresolver.UrlSecretType) (*corev1.LocalObjectReference, error) {
 		return nil, nil

--- a/pkg/utils/rcontext/rcontext_test.go
+++ b/pkg/utils/rcontext/rcontext_test.go
@@ -38,12 +38,12 @@ func TestWithVersionResolver(t *testing.T) {
 	}
 }
 
-func TestWithVersionsResolver(t *testing.T) {
+func TestWithAvailableVersionsResolver(t *testing.T) {
 	fn := func(componentName string) ([]string, error) {
 		return []string{"1.0.0"}, nil
 	}
-	ctx := WithVersionsResolver(context.TODO(), fn)
-	actual := VersionsResolver(ctx)
+	ctx := WithAvailableVersionsResolver(context.TODO(), fn)
+	actual := AvailableVersionsResolver(ctx)
 	if reflect.ValueOf(actual).Pointer() != reflect.ValueOf(fn).Pointer() {
 		t.Error("Functions are not equal")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements gracefully handling missing versions from releasechannels. Previously if a component was running but not installable anymore, the component was marked as unready and the user received an error that the component was not installable with the specified version. Now the component remains ready if it is still running and the user receives a message informing about the currently component version not being available anymore and the available versions.

**Which issue(s) this PR fixes**:
Fixes #15 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Greacefully handle missing component versions on already installed components
```
