### PR TITLE
chore: replace SAP references with NeoNephos/OpenControlPlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,4 +168,20 @@ We as members, contributors, and leaders pledge to make participation in our com
 
 ## Licensing
 
-Copyright © Linux Foundation Europe. OpenControlPlane is a project of NeoNephos Foundation. For applicable policies including privacy policy, terms of use and trademark usage guidelines, please see https://linuxfoundation.eu. Linux is a registered trademark of Linus Torvalds. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/openmcp-project/control-plane-operator).
+
+
+---
+
+<p align="center">
+  <a href="https://apeirora.eu/content/projects/">
+    <img alt="BMWK-EU funding logo" src="https://apeirora.eu/assets/img/BMWK-EU.png" width="300"/>
+  </a>
+</p>
+
+<p align="center">
+  OpenControlPlane is part of <a href="https://apeirora.eu/content/projects/">ApeiroRA</a>, an EU Important Project of Common European Interest (IPCEI-CIS).
+</p>
+
+<p align="center">
+  Copyright Linux Foundation Europe. For web site terms of use, trademark policy and other project policies please see <a href="https://linuxfoundation.eu/en/policies">https://linuxfoundation.eu/en/policies</a>.
+</p>


### PR DESCRIPTION
## What

Replace SAP-era copyright headers and policy references with NeoNephos/OpenControlPlane equivalents.

- Copyright headers: `SAP SE or an SAP affiliate company` → `OpenControlPlane contributors`
- REUSE.toml: updated to neutral template
- Contact emails: `ospo@sap.com` → `support@neonephos.org`
- Removed SAP legal/policy links
- Removed repo-local community health files now inherited from `.github`
- Added required NeoNephos/LF Europe footer to README.md (§7, §12)

**Not changed:** BTP doc links, `ghcr.io/sap` images, `sap.com/v1alpha1` API group.

## Why

Per [NeoNephos Project Guidelines](https://github.com/neonephos/guidelines-development/blob/main/project-guidelines/project-guidelines.md) (Sections 7, 9). Part of https://github.com/openmcp-project/backlog/issues/533.